### PR TITLE
chore: remove checking on main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,6 @@ version: 2
 updates:
     - package-ecosystem: 'npm'
       directory: '/'
-      target-branch: 'main'
-      schedule:
-          interval: 'weekly'
-          day: 'sunday'
-
-    - package-ecosystem: 'npm'
-      directory: '/'
       target-branch: 'development'
       schedule:
           interval: 'daily'


### PR DESCRIPTION
we dont need to check `main` branch for updates as `development` branch is always up-to-date with `main` branch